### PR TITLE
Using different env for pyspark_python for transformers and analysers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ ENV DATA_TRANSFORMERS_VERSION v-dev
 ENV ANALYSERS_VERSION v-dev
 ENV PLUGINS_VERSION v-dev
 
+ENV REGULAR_PYTHON /usr/bin/python2.7
+ENV CONDA_PYTHON /opt/conda/python2.7
+
 # Configure environment for miniconda
 ENV CONDA_DIR=/opt/conda
 ENV PATH=$CONDA_DIR/bin:$PATH
@@ -107,13 +110,13 @@ RUN apk upgrade --update && \
 
 # adds Alpine's testing repository and install scripts dependencies (py-numpy, py-yaml)
 RUN sed -i -e '$a@testing http://dl-4.alpinelinux.org/alpine/edge/testing' /etc/apk/repositories \    
-    && apk --update add py-numpy@testing py-yaml
+    && apk --update add py-numpy@testing py-scipy@testing py-yaml py-dateutil
 
 # adds pip and install scripts dependencies (future)
 RUN apk --update add py-pip \
     && pip install --upgrade pip \
-    && pip install future \
-    && pip install minio \
+    && ${REGULAR_PYTHON} /usr/bin/pip install future \
+    && ${REGULAR_PYTHON} /usr/bin/pip install minio \
     && apk del --purge py-pip \
     && rm -rf /var/cache/apk/*
  

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -16,6 +16,9 @@ ENV DATA_TRANSFORMERS_VERSION v-dev
 ENV ANALYSERS_VERSION v-dev
 ENV PLUGINS_VERSION v-dev
 
+ENV REGULAR_PYTHON /usr/bin/python2.7
+ENV CONDA_PYTHON /opt/conda/python2.7
+
 # Configure environment for miniconda
 ENV CONDA_DIR=/opt/conda
 ENV PATH=$CONDA_DIR/bin:$PATH
@@ -108,16 +111,16 @@ RUN apk upgrade --update && \
     conda install -c anaconda dateutil=2.4.1 && \
     # TODO: evaluate if possible to remove miniconda and its dependencies (git, bzip2, unzip, sudo, libstdc++, glib, libxext, libxrender) at this point
     apk del glibc-i18n
-
+    
 # adds Alpine's testing repository and install scripts dependencies (py-numpy, py-yaml)
 RUN sed -i -e '$a@testing http://dl-4.alpinelinux.org/alpine/edge/testing' /etc/apk/repositories \    
-    && apk --update add py-numpy@testing py-yaml
+    && apk --update add py-numpy@testing py-scipy@testing py-yaml py-dateutil
 
 # adds pip and install scripts dependencies (future)
 RUN apk --update add py-pip \
     && pip install --upgrade pip \
-    && pip install future \
-    && pip install minio \
+    && ${REGULAR_PYTHON} /usr/bin/pip install future \
+    && ${REGULAR_PYTHON} /usr/bin/pip install minio \
     && apk del --purge py-pip \
     && rm -rf /var/cache/apk/*
     


### PR DESCRIPTION
Due to issues with the libraries needed for Spark and Python (Numpy, Scipy, Minio,...) we need to use a different PYSPARK_PYTHON setting for analysers and data-transformers, using the conda env with the analysers, and the normal python2.7 env with the transformers

<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/data-analyses-scheduler/pull/76?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/data-analyses-scheduler/pull/76'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
