### PR TITLE
Removed collector name from trial counter key (caused conflicts)

### DIFF
--- a/src/cloud/benchflow/data-analyses-scheduler/consumers/analyserConsumer.go
+++ b/src/cloud/benchflow/data-analyses-scheduler/consumers/analyserConsumer.go
@@ -44,7 +44,7 @@ func submitWorksThatMeetReqs(request WorkRequest, r string, analyserScripts []An
 // Submit the work when trial counter of a script matches the total num of trials for an experiment
 func submitWorksThatMeetTrialCount(request WorkRequest, r string, analyserScripts []AnalyserScript) {
 	for _, sc := range analyserScripts {
-		counterId := scripts.GetCounterID(request.ExperimentID, sc.ScriptName, request.ContainerName, request.HostID, request.CollectorName)
+		counterId := scripts.GetCounterID(request.ExperimentID, sc.ScriptName, request.ContainerName, request.HostID)
 		i, ok := TrialCount.Get(counterId)
 		if ok && i.(int) == request.TotalTrialsNum {
 			TrialCount.Remove(counterId)

--- a/src/cloud/benchflow/data-analyses-scheduler/scripts/requirements.go
+++ b/src/cloud/benchflow/data-analyses-scheduler/scripts/requirements.go
@@ -64,6 +64,6 @@ func IsExperimentComplete(experimentID string) bool{
 }
 
 // Function that generates the key for the trial counter map
-func GetCounterID(experimentID string, scriptName string, containerName string, hostID string, collectorName string) string {
-	return experimentID+"_"+scriptName+"_"+containerName+"_"+hostID+"_"+collectorName
+func GetCounterID(experimentID string, scriptName string, containerName string, hostID string) string {
+	return experimentID+"_"+scriptName+"_"+containerName+"_"+hostID
 }

--- a/src/cloud/benchflow/data-analyses-scheduler/workers/analyserWorker.go
+++ b/src/cloud/benchflow/data-analyses-scheduler/workers/analyserWorker.go
@@ -41,7 +41,7 @@ func (w *AnalyserWorker) Start() {
 				scripts.MeetRequirement(work.ScriptName, work.TrialID, work.ExperimentID, work.Level)
 			}
 			// Increment counter for trials completed for the given script
-			counterId := scripts.GetCounterID(work.ExperimentID, work.ScriptName, work.ContainerName, work.HostID, work.CollectorName)
+			counterId := scripts.GetCounterID(work.ExperimentID, work.ScriptName, work.ContainerName, work.HostID)
 			TrialCount.SetIfAbsent(counterId, 0)
 			i, ok := TrialCount.Get(counterId)
 			if ok {


### PR DESCRIPTION
Due to the changes to the scheduler, using collector name in the trial counter key caused issues when multiple dependencies from the transformer are involved. Removing it fixes the problem.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/data-analyses-scheduler/pull/77?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/data-analyses-scheduler/pull/77'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
