### PR TITLE
Added hash to retrieve minio config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN apk upgrade --update && \
 
 # adds Alpine's testing repository and install scripts dependencies (py-numpy, py-yaml)
 RUN sed -i -e '$a@testing http://dl-4.alpinelinux.org/alpine/edge/testing' /etc/apk/repositories \    
-    && apk --update add py-numpy@testing py-scipy@testing py-yaml py-dateutil
+    && apk --update add py-yaml py-dateutil
 
 # adds pip and install scripts dependencies (future)
 RUN apk --update add py-pip \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -114,7 +114,7 @@ RUN apk upgrade --update && \
     
 # adds Alpine's testing repository and install scripts dependencies (py-numpy, py-yaml)
 RUN sed -i -e '$a@testing http://dl-4.alpinelinux.org/alpine/edge/testing' /etc/apk/repositories \    
-    && apk --update add py-numpy@testing py-scipy@testing py-yaml py-dateutil
+    && apk --update add py-yaml py-dateutil
 
 # adds pip and install scripts dependencies (future)
 RUN apk --update add py-pip \

--- a/src/cloud/benchflow/data-analyses-scheduler/config/configFromMinio.go
+++ b/src/cloud/benchflow/data-analyses-scheduler/config/configFromMinio.go
@@ -3,9 +3,20 @@ package config
 import (
 	"github.com/minio/minio-go"
 	"strings"
+	"crypto/md5"
+	"encoding/hex"
 	"gopkg.in/yaml.v2"
 	. "cloud/benchflow/data-analyses-scheduler/vars"
 )
+
+// TODO: Take the commons one
+const numOfHashCharacters int = 4
+func hashKey(key string) string {
+	hasher := md5.New()
+    hasher.Write([]byte(key))
+    hashString := hex.EncodeToString(hasher.Sum(nil))
+	return (hashString[:numOfHashCharacters])
+	}
 
 // Retrieve the test configuration from Minio
 func TakeTestConfigFromMinio(experimentID string) (int, string, string, string, error) {
@@ -31,7 +42,9 @@ func TakeTestConfigFromMinio(experimentID string) (int, string, string, string, 
 	}
 	
 	// Path of the file
-	path := strings.Replace(experimentID, ".", "/", -1)
+	lastDotIndex := strings.LastIndex(experimentID, ".")
+	hash := hashKey(experimentID[:lastDotIndex])
+	path := hash+"/"+(strings.Replace(experimentID, ".", "/", -1))
 	
 	// Get object info
 	objInfo, err := minioClient.StatObject(TestsConfigBucket, path+"/"+TestsConfigName)


### PR DESCRIPTION
Before it wouldn’t retrieve the configuration of the benchmark from Minio due to missing hash.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/data-analyses-scheduler/pull/78?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/data-analyses-scheduler/pull/78'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
