### PR TITLE
Fix for configuration path

### DIFF
--- a/src/cloud/benchflow/data-analyses-scheduler/scripts/scriptSubmission.go
+++ b/src/cloud/benchflow/data-analyses-scheduler/scripts/scriptSubmission.go
@@ -73,9 +73,5 @@ func checkForErrors(errLog string) bool {
 	if strings.Contains(errString, "exception") {
 		return true
 		}
-	//TODO: Find a better way to identify error tracebacks
-	if strings.Contains(errString, "traceback") {
-		return true
-		}
 	return false
 	}

--- a/src/cloud/benchflow/data-analyses-scheduler/scripts/scriptSubmission.go
+++ b/src/cloud/benchflow/data-analyses-scheduler/scripts/scriptSubmission.go
@@ -73,5 +73,9 @@ func checkForErrors(errLog string) bool {
 	if strings.Contains(errString, "exception") {
 		return true
 		}
+	//TODO: Find a better way to identify error tracebacks
+	if strings.Contains(errString, "traceback") {
+		return true
+		}
 	return false
 	}

--- a/src/cloud/benchflow/data-analyses-scheduler/scripts/sparkArgsConstructors.go
+++ b/src/cloud/benchflow/data-analyses-scheduler/scripts/sparkArgsConstructors.go
@@ -11,6 +11,8 @@ import (
 func getConfigFilePath(SUTVersion string, SUTName string, SUTType string, fileName string) string {
 	// Split the version into 3 numbers (eg. 1.0.2 -> [1 0 2])
 	versionNums := strings.Split(SUTVersion, ".")
+	SUTName = strings.ToLower(SUTName)
+	SUTType = strings.ToLower(SUTType)
 	dirs, _ := ioutil.ReadDir(AppPath+"/"+TransformersConfigurationsPath+"/"+SUTType+"/"+SUTName)
 	// Iterate over the dirs, finds the one for the version passed to the function, either a perfect match or matching a range (eg. 1.2.0-1.4.0 for 1.3.0)
     for _, dir := range dirs {


### PR DESCRIPTION
Fixes https://github.com/benchflow/data-transformers/issues/86

The fix assumes that all the folders and files in the plugin repo are lowercase. That is fine for now, for the sake of traceability, I took a note in benchflow/sut-plugins#4
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/benchflow/data-analyses-scheduler/pull/83%23discussion_r75599409%22%2C%20%22https%3A//github.com/benchflow/data-analyses-scheduler/pull/83%23discussion_r75599464%22%2C%20%22https%3A//github.com/benchflow/data-analyses-scheduler/pull/83%23discussion_r75599967%22%2C%20%22https%3A//github.com/benchflow/data-analyses-scheduler/pull/83%23discussion_r75600005%22%2C%20%22https%3A//github.com/benchflow/data-analyses-scheduler/pull/83%23discussion_r75600007%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20b6a667f74e728c95caef913af3527b7f4f6c456a%20src/cloud/benchflow/data-analyses-scheduler/scripts/scriptSubmission.go%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benchflow/data-analyses-scheduler/pull/83%23discussion_r75599409%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Does%20this%20belong%20to%20the%20current%20pull%3F%20I%20guess%20it%20does%20not%2C%20it%20is%20more%20related%20to%20https%3A//github.com/benchflow/data-analyses-scheduler/issues/82.%20Roll%20back%20the%20change%20and%20perform%20it%20in%20a%20different%20pull.%22%2C%20%22created_at%22%3A%20%222016-08-21T17%3A27%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40VincenzoFerme%20Okay%22%2C%20%22created_at%22%3A%20%222016-08-21T17%3A49%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8819678%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Cerfoglg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-08-21T17%3A52%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/cloud/benchflow/data-analyses-scheduler/scripts/scriptSubmission.go%3AL73-82%22%7D%2C%20%22Pull%20b6a667f74e728c95caef913af3527b7f4f6c456a%20src/cloud/benchflow/data-analyses-scheduler/scripts/sparkArgsConstructors.go%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benchflow/data-analyses-scheduler/pull/83%23discussion_r75599464%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20assumes%20that%20all%20the%20folders%20and%20files%20in%20the%20plugin%20repo%20are%20lowercase.%20That%20is%20fine%20for%20now%2C%20for%20the%20sake%20of%20traceability%2C%20I%20took%20a%20note%20in%20https%3A//github.com/benchflow/sut-plugins/issues/4%22%2C%20%22created_at%22%3A%20%222016-08-21T17%3A29%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-08-21T17%3A52%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/cloud/benchflow/data-analyses-scheduler/scripts/sparkArgsConstructors.go%3AL11-19%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull b6a667f74e728c95caef913af3527b7f4f6c456a src/cloud/benchflow/data-analyses-scheduler/scripts/scriptSubmission.go 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benchflow/data-analyses-scheduler/pull/83#discussion_r75599409'>File: src/cloud/benchflow/data-analyses-scheduler/scripts/scriptSubmission.go:L73-82</a></b>
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> Does this belong to the current pull? I guess it does not, it is more related to https://github.com/benchflow/data-analyses-scheduler/issues/82. Roll back the change and perform it in a different pull.
- <a href='https://github.com/Cerfoglg'><img border=0 src='https://avatars.githubusercontent.com/u/8819678?v=3' height=16 width=16'></a> @VincenzoFerme Okay
- [x] <a href='#crh-comment-Pull b6a667f74e728c95caef913af3527b7f4f6c456a src/cloud/benchflow/data-analyses-scheduler/scripts/sparkArgsConstructors.go 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benchflow/data-analyses-scheduler/pull/83#discussion_r75599464'>File: src/cloud/benchflow/data-analyses-scheduler/scripts/sparkArgsConstructors.go:L11-19</a></b>
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> This assumes that all the folders and files in the plugin repo are lowercase. That is fine for now, for the sake of traceability, I took a note in https://github.com/benchflow/sut-plugins/issues/4

<a href='https://www.codereviewhub.com/benchflow/data-analyses-scheduler/pull/83?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/benchflow/data-analyses-scheduler/pull/83?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/data-analyses-scheduler/pull/83'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
