### PR TITLE
More explicit checking for spark error logs

### DIFF
--- a/src/cloud/benchflow/data-analyses-scheduler/scripts/scriptSubmission.go
+++ b/src/cloud/benchflow/data-analyses-scheduler/scripts/scriptSubmission.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 	"os"
 	"strings"
-	//"bytes"
+	"bytes"
 	. "cloud/benchflow/data-analyses-scheduler/vars"
 )
 
@@ -37,15 +37,23 @@ func SubmitScript(args []string, script string) bool {
 	cmd.Env = env
 	for retries < 3 {
 		retries += 1
-		out, err := cmd.CombinedOutput()
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		err := cmd.Run()
 		if err != nil {
 			fmt.Println("Script "+script+" exited with a fatal error")
-			fmt.Println(out)
-			fmt.Println(err)
+			fmt.Println(out.String())
+			fmt.Println(stderr.String())
 			return false
 		}
-		fmt.Println(out)
-		if checkForErrors(string(out)) {
+		fmt.Println(out.String())
+		if checkForErrors(stderr.String()) {
+			fmt.Println("Script " + script + " exited with an error")
+			continue
+		}
+		if checkForErrors(out.String()) {
 			fmt.Println("Script " + script + " exited with an error")
 			continue
 		}


### PR DESCRIPTION
Manually redirecting stdout and stderror to force Golang to print the entire error message by the Spark scripts in case of failure.

Related to https://github.com/benchflow/data-analyses-scheduler/issues/87

<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/benchflow/data-analyses-scheduler/pull/91?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/data-analyses-scheduler/pull/91'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
